### PR TITLE
To mock registerCertificate function in JavaScript SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,24 +90,18 @@ class ClientServiceBase {
    * @return {Promise<ClientServiceResponse>}
    */
   async registerCertificate() {
-    const request = new CertificateRegistrationRequestBuilder(
-        new this.protobuf.CertificateRegistrationRequest()
-    ).withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion)
-        .withCertPem(this.certPem)
-        .build();
+    // TODO re-implement later
+    // const request = new CertificateRegistrationRequestBuilder(
+    //     new this.protobuf.CertificateRegistrationRequest()
+    // ).withCertHolderId(this.certHolderId)
+    //     .withCertVersion(this.certVersion)
+    //     .withCertPem(this.certPem)
+    //     .build();
     return this.sendRequest('registerCert', () =>
-      new Promise((resolve, reject) => {
-        this.ledgerClient.registerCert(request,
-            this.metadata, (err, response) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve(response);
-              }
-            });
-      }
-      ));
+      new Promise((_, reject) => {
+        reject(new Error('This method will be reimplemented later'));
+      })
+    );
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jsrsasign": "^8.0.12"
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Scalar DL server will change the interface of certificate registration to enhance security.
In this PR, we mock current implementation which is based on gRPC `rpc.Ledger.RegisterCert` service for the time being and re-implement with `rpc.LedgerPrivileged.RegisterCert` later.