### PR TITLE
Add optional function argument parameter for executeContract

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,16 +198,19 @@ class ClientServiceBase {
   /**
    * @param {number} contractId
    * @param {Object} argument
+   * @param {Object} [functionArgument=null]
    * @return {Promise<ClientServiceResponse|void|*>}
    */
-  async executeContract(contractId, argument) {
+  async executeContract(contractId, argument, functionArgument = null) {
     argument['nonce'] = new Date().getTime().toString();
     const argumentJson = JSON.stringify(argument);
+    const functionArgumentJson = JSON.stringify(functionArgument);
 
     const request = new ContractExecutionRequestBuilder(
         new this.protobuf.ContractExecutionRequest(), this.signer)
         .withContractId(contractId)
         .withContractArgument(argumentJson)
+        .withFunctionArgument(functionArgumentJson)
         .withCertHolderId(this.certHolderId)
         .withCertVersion(this.certVersion)
         .build();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jsrsasign": "^8.0.12"
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/request/builder.js
+++ b/request/builder.js
@@ -417,6 +417,16 @@ class ContractExecutionRequestBuilder {
   }
 
   /**
+   * Sets the function argument
+   * @param {string} argument
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withFunctionArgument(argument) {
+    this.functionArgument = argument;
+    return this;
+  }
+
+  /**
    * Builds the ContractExecutionRequest
    * @return {ContractExecutionRequest}
    */
@@ -426,6 +436,7 @@ class ContractExecutionRequestBuilder {
     request.setContractArgument(this.contractArgument);
     request.setCertHolderId(this.certHolderId);
     request.setCertVersion(this.certVersion);
+    request.setFunctionArgument(this.functionArgument);
 
     const contractIdEncoded = new TextEncoder('utf-8').encode(this.contractId);
     const contractArgument = new TextEncoder('utf-8')


### PR DESCRIPTION
Scalar DL supports user defined functions execution from contracts.
Thus, this PR implement an optional parameter in executeContract function according to the updated scalar.proto.