### PR TITLE
Bugfix: executeContract failed to execute contract when function argument is null 

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,10 +198,10 @@ class ClientServiceBase {
   /**
    * @param {number} contractId
    * @param {Object} argument
-   * @param {Object} [functionArgument=null]
+   * @param {Object} [functionArgument=undefined]
    * @return {Promise<ClientServiceResponse|void|*>}
    */
-  async executeContract(contractId, argument, functionArgument = null) {
+  async executeContract(contractId, argument, functionArgument) {
     argument['nonce'] = new Date().getTime().toString();
     const argumentJson = JSON.stringify(argument);
     const functionArgumentJson = JSON.stringify(functionArgument);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jsrsasign": "^8.0.12"
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
According to #9 , we found gRPC JavaScript stub will convert `null` to `"null"` if we use it on a string field. Setting undefined can make the string field to be real null.