### PR TITLE
Add new signer using elliptic library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "elliptic": "^6.5.1",
     "jsrsasign": "^8.0.12"
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",

--- a/signer.js
+++ b/signer.js
@@ -1,7 +1,9 @@
+const crypto = require('crypto');
+const elliptic = require('elliptic');
 const jsrsasign = require('jsrsasign');
 
 /**
- * This class is used for signing certificates
+ * This class is a base class for signing certificates
  */
 class SignatureSigner {
   /**
@@ -9,6 +11,36 @@ class SignatureSigner {
    */
   constructor(pem) {
     this.pem = pem;
+  }
+
+  /**
+   * This method must be implemented for all signer class
+   * @param {Uint8Array} content
+   */
+  sign(content) {
+    throw new Error(`sign is not implemented`);
+  }
+
+  /**
+   * This method must be implemented for all signer class
+   * @return {string}
+   */
+  getBase64PemString() {
+    return this.pem.replace('-----BEGIN EC PRIVATE KEY-----', '').
+        replace('-----END EC PRIVATE KEY-----', '').
+        replace(/\n/g, '');
+  }
+}
+
+/**
+ * This class is used for signing certificates using jsrsasign library
+ */
+class JsrsasignSignatureSigner extends SignatureSigner {
+  /**
+   * @param {string} pem
+   */
+  constructor(pem) {
+    super(pem);
   }
 
   /**
@@ -20,9 +52,7 @@ class SignatureSigner {
     const hex = jsrsasign.ArrayBuffertohex(content.buffer);
     const ecdsa = new jsrsasign.KJUR.crypto.ECDSA();
     try {
-      const base64 = this.pem.replace('-----BEGIN EC PRIVATE KEY-----', '').
-          replace('-----END EC PRIVATE KEY-----', '').
-          replace(/\n/g, '');
+      const base64 = this.getBase64PemString();
       ecdsa.readPKCS5PrvKeyHex(jsrsasign.b64utohex(base64));
     } catch (err) {
       throw new Error(`Failed to load private key ${err}`);
@@ -42,6 +72,42 @@ class SignatureSigner {
   }
 }
 
+/**
+ * This class is used for signing certificates using elliptic library
+ */
+class EllipticSignatureSigner extends SignatureSigner {
+  /**
+   * @param {string} pem
+   */
+  constructor(pem) {
+    super(pem);
+  }
+
+  /**
+   * This method is used for signing the content
+   * @param {Uint8Array} content
+   * @return {Uint8Array}
+   */
+  sign(content) {
+    try {
+      const base64 = this.getBase64PemString();
+      const {prvKeyHex} = jsrsasign.KEYUTIL.getKey(
+          jsrsasign.b64utohex(base64), null, 'pkcs5prv');
+      const EC = elliptic.ec;
+      const ecdsaCurve = elliptic.curves['p256'];
+      const ecdsa = new EC(ecdsaCurve);
+      const signKey = ecdsa.keyFromPrivate(prvKeyHex, 'hex');
+      const sha256 = crypto.createHash('sha256');
+      const digest = sha256.update(content).digest();
+      const signature = ecdsa.sign(Buffer.from(digest, 'hex'), signKey);
+      return new Uint8Array(signature.toDER());
+    } catch (err) {
+      throw new Error(`Failed to sign the request ${err}`);
+    }
+  }
+}
+
 module.exports = {
-  SignatureSigner,
+  SignatureSigner: EllipticSignatureSigner, // Use elliptic library as default
+  JsrsasignSignatureSigner,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+bn.js@^4.4.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -99,6 +104,11 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -249,6 +259,19 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+elliptic@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
+  integrity sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -560,10 +583,27 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hmac-drbg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -602,6 +642,11 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+inherits@^2.0.1, inherits@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inquirer@^6.2.2:
   version "6.3.1"
@@ -771,6 +816,16 @@ mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This patch set adds a new singer that uses fast elliptic library to improve performance. Background and improved performance can be found in https://github.com/scalar-labs/investigation/tree/master/signbench.