### PR TITLE
Fix properties naming and create two classes for handling responses

### DIFF
--- a/asset_proof.js
+++ b/asset_proof.js
@@ -18,7 +18,7 @@ class AssetProof {
   }
 
   /**
-   * @param {gRPCAssestProof} proof
+   * @param {proto.rpc.AssetProof} proof
    * @return {AssetProof}
    */
   static fromGrpcAssetProof(proof) {

--- a/asset_proof.js
+++ b/asset_proof.js
@@ -1,0 +1,83 @@
+/**
+ * AssetProof class
+ */
+class AssetProof {
+  /**
+    * @param {string} id
+    * @param {number} age
+    * @param {Uint8Array} hash
+    * @param {string} nonce
+    * @param {Uint8Array} signature
+    */
+  constructor(id, age, hash, nonce, signature) {
+    this.id = id;
+    this.age = age;
+    this.hash = hash;
+    this.nonce = nonce;
+    this.signature = signature;
+  }
+
+  /**
+   * @param {gRPCAssestProof} proof
+   * @return {AssetProof}
+   */
+  static fromGRPCAssetProof(proof) {
+    return new AssetProof(
+        proof.getAssetId(),
+        proof.getAge(),
+        proof.getHash_asU8() | new Uint8Array(),
+        proof.getNonce(),
+        proof.getSignature_asU8() | new Uint8Array(),
+    );
+  }
+
+  /**
+   * @return {string}
+   */
+  getId() {
+    return this.id;
+  }
+
+  /**
+   * @return {number}
+   */
+  getAge() {
+    return this.age;
+  }
+
+  /**
+   * @return {Uint8Array}
+   */
+  getHash() {
+    return this.hash;
+  }
+
+  /**
+   * @return {string}
+   */
+  getNonce() {
+    return this.nonce;
+  }
+
+  /**
+   * @return {Uint8Array}
+   */
+  getSignature() {
+    return this.signature;
+  }
+
+  /**
+   * @return {string}
+   */
+  toString() {
+    return `AssetProof{id=${this.id},`
+        + `age${this.age}},`
+        + `hash=${this.hash},`
+        + `nonce=${this.nonce},`
+        + `signature=${this.signature}}`;
+  }
+}
+
+module.exports = {
+  AssetProof,
+};

--- a/asset_proof.js
+++ b/asset_proof.js
@@ -1,5 +1,5 @@
 /**
- * AssetProof class
+ * @public
  */
 class AssetProof {
   /**

--- a/asset_proof.js
+++ b/asset_proof.js
@@ -21,7 +21,7 @@ class AssetProof {
    * @param {gRPCAssestProof} proof
    * @return {AssetProof}
    */
-  static fromGRPCAssetProof(proof) {
+  static fromGrpcAssetProof(proof) {
     return new AssetProof(
         proof.getAssetId(),
         proof.getAge(),

--- a/client_error.js
+++ b/client_error.js
@@ -1,6 +1,7 @@
 /**
  * Generic error thrown by the SDK.
  * @extends {Error}
+ * @public
  */
 class ClientError extends Error {
   /**

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -14,7 +14,7 @@ class ContractExecutionResult {
   }
 
   /**
-   * @param {gRPCContractExecutionResponse} response
+   * @param {proto.rpc.ContractExecutionResponse} response
    * @return {ContractExecutionResult}
    */
   static fromGrpcContractExecutionResponse(response) {

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -1,3 +1,5 @@
+const {AssetProof} = require('./asset_proof.js');
+
 /**
  * To handle ContractExecutionResponse
  */
@@ -9,6 +11,24 @@ class ContractExecutionResult {
   constructor(result, proofs) {
     this.result = result;
     this.proofs = proofs;
+  }
+
+  /**
+   * @param {gRPCContractExecutionResponse} response
+   * @return {ContractExecutionResult}
+   */
+  static fromGRPCContractExecutionResponse(response) {
+    const resultInString = response.getResult();
+    const resultInObject = (resultInString)
+      ? JSON.parse(resultInString)
+      : {};
+
+    return new ContractExecutionResult(
+        resultInObject,
+        response.getProofsList().map(
+            (proof) => AssetProof.fromGRPCAssetProof(proof),
+        ),
+    );
   }
 
   /**

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -1,0 +1,9 @@
+/**
+ * To handle ContractExecutionResponse
+ */
+class ContractExecutionResult {
+}
+
+module.exports = {
+  ContractExecutionResult,
+};

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -26,7 +26,7 @@ class ContractExecutionResult {
     return new ContractExecutionResult(
         resultInObject,
         response.getProofsList().map(
-            (proof) => AssetProof.fromGRPCAssetProof(proof),
+            (proof) => AssetProof.fromGrpcAssetProof(proof),
         ),
     );
   }

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -2,6 +2,28 @@
  * To handle ContractExecutionResponse
  */
 class ContractExecutionResult {
+  /**
+   * @param {Object} result
+   * @param {Array} proofs
+   */
+  constructor(result, proofs) {
+    this.result = result;
+    this.proofs = proofs;
+  }
+
+  /**
+   * @return {Object}
+   */
+  getResult() {
+    return this.result;
+  }
+
+  /**
+   * @return {Array}
+   */
+  getProofs() {
+    return this.proofs;
+  }
 }
 
 module.exports = {

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -1,7 +1,7 @@
 const {AssetProof} = require('./asset_proof.js');
 
 /**
- * To handle ContractExecutionResponse
+ * @public
  */
 class ContractExecutionResult {
   /**

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -17,7 +17,7 @@ class ContractExecutionResult {
    * @param {gRPCContractExecutionResponse} response
    * @return {ContractExecutionResult}
    */
-  static fromGRPCContractExecutionResponse(response) {
+  static fromGrpcContractExecutionResponse(response) {
     const resultInString = response.getResult();
     const resultInObject = (resultInString)
       ? JSON.parse(resultInString)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const {
   FunctionRegistrationRequestBuilder,
   ContractExecutionRequestBuilder,
 } = require('./request/builder');
-
+const {ContractExecutionResult} = require('./contract_execution_result');
 const {EllipticSigner, WebCryptoSigner} = require('./signer');
 
 /**
@@ -356,9 +356,17 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              const jsonResponse = response.toObject();
-              jsonResponse.result = JSON.parse(jsonResponse.result);
-              resolve(jsonResponse);
+              const resultInString = response.getResult();
+              const resultInObject = (resultInString)
+                ? JSON.parse(resultInString)
+                : {};
+
+              const contractExecutionResult = new ContractExecutionResult(
+                  resultInObject,
+                  response.getProofsList().map((proof) => proof.toObject()),
+              );
+
+              resolve(contractExecutionResult);
             }
           },
       );
@@ -428,4 +436,5 @@ module.exports = {
   ClientServiceBase,
   ClientError,
   StatusCode,
+  ContractExecutionResult,
 };

--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ class ClientServiceBase {
               reject(err);
             } else {
               resolve(
-                  LedgerValidationResult.fromGRPCLedgerValidationResponse(
+                  LedgerValidationResult.fromGrpcLedgerValidationResponse(
                       response,
                   ),
               );
@@ -363,7 +363,7 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              resolve(ContractExecutionResult.fromGRPCContractExecutionResponse(
+              resolve(ContractExecutionResult.fromGrpcContractExecutionResponse(
                   response,
               ));
             }

--- a/index.js
+++ b/index.js
@@ -310,12 +310,11 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              const ledgerValidationResult = new LedgerValidationResult(
-                  response.getStatusCode(),
-                  AssetProof.fromGRPCAssetProof(response.getProof()),
+              resolve(
+                  LedgerValidationResult.fromGRPCLedgerValidationResponse(
+                      response,
+                  ),
               );
-
-              resolve(ledgerValidationResult);
             }
           },
       );
@@ -363,19 +362,9 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              const resultInString = response.getResult();
-              const resultInObject = (resultInString)
-                ? JSON.parse(resultInString)
-                : {};
-
-              const contractExecutionResult = new ContractExecutionResult(
-                  resultInObject,
-                  response.getProofsList().map(
-                      (proof) => AssetProof.fromGRPCAssetProof(proof),
-                  ),
-              );
-
-              resolve(contractExecutionResult);
+              resolve(ContractExecutionResult.fromGRPCContractExecutionResponse(
+                  response,
+              ));
             }
           },
       );

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const {EllipticSigner, WebCryptoSigner} = require('./signer');
  * and contracts, listing contracts, validating the ledger, and executing
  * contracts.
  * @class
+ * @public
  */
 class ClientServiceBase {
   /**

--- a/index.js
+++ b/index.js
@@ -28,31 +28,31 @@ class ClientServiceBase {
     /** @const */
     this.properties = properties;
     /** @const */
-    this.serverHost = properties['scalar.ledger.client.server_host'];
+    this.serverHost = properties['scalar.dl.client.server.host'];
     /** @const */
-    this.serverPort = properties['scalar.ledger.client.server_port'];
+    this.serverPort = properties['scalar.dl.client.server.port'];
     /** @const */
-    this.tlsEnabled = properties['scalar.ledger.client.tls.enabled'];
+    this.tlsEnabled = properties['scalar.dl.client.tls.enabled'];
     if (this.tlsEnabled !== undefined && typeof this.tlsEnabled !== 'boolean') {
       throw new ClientError(
           StatusCode.CLIENT_IO_ERROR,
-          'property \'scalar.ledger.client.tls.enabled\' is not a boolean',
+          'property \'scalar.dl.client.tls.enabled\' is not a boolean',
       );
     }
     /** @const */
     this.privateKeyPem = this._getRequiredProperty(properties,
-        'scalar.ledger.client.private_key_pem');
+        'scalar.dl.client.private_key_pem');
     /** @const */
     this.certPem = this._getRequiredProperty(properties,
-        'scalar.ledger.client.cert_pem');
+        'scalar.dl.client.cert_pem');
     /** @const */
     this.certHolderId = this._getRequiredProperty(properties,
-        'scalar.ledger.client.cert_holder_id');
+        'scalar.dl.client.cert_holder_id');
     /** @const */
     this.credential =
-      properties['scalar.ledger.client.authorization.credential'];
+      properties['scalar.dl.client.authorization.credential'];
     /** @const */
-    this.certVersion = properties['scalar.ledger.client.cert_version'];
+    this.certVersion = properties['scalar.dl.client.cert_version'];
 
     /** @const */
     this.metadata = {};

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {
   ContractExecutionRequestBuilder,
 } = require('./request/builder');
 const {ContractExecutionResult} = require('./contract_execution_result');
+const {LedgerValidationResult} = require('./ledger_validation_result');
 const {EllipticSigner, WebCryptoSigner} = require('./signer');
 
 /**
@@ -308,7 +309,13 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              resolve(response.toObject());
+              const proof = response.getProof();
+              const ledgerValidationResult = new LedgerValidationResult(
+                  response.getStatusCode(),
+                  proof ? proof.toObject() : {},
+              );
+
+              resolve(ledgerValidationResult);
             }
           },
       );
@@ -437,4 +444,5 @@ module.exports = {
   ClientError,
   StatusCode,
   ContractExecutionResult,
+  LedgerValidationResult,
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
 } = require('./request/builder');
 const {ContractExecutionResult} = require('./contract_execution_result');
 const {LedgerValidationResult} = require('./ledger_validation_result');
+const {AssetProof} = require('./asset_proof');
 const {EllipticSigner, WebCryptoSigner} = require('./signer');
 
 /**
@@ -309,10 +310,9 @@ class ClientServiceBase {
             if (err) {
               reject(err);
             } else {
-              const proof = response.getProof();
               const ledgerValidationResult = new LedgerValidationResult(
                   response.getStatusCode(),
-                  proof ? proof.toObject() : {},
+                  AssetProof.fromGRPCAssetProof(response.getProof()),
               );
 
               resolve(ledgerValidationResult);
@@ -370,7 +370,9 @@ class ClientServiceBase {
 
               const contractExecutionResult = new ContractExecutionResult(
                   resultInObject,
-                  response.getProofsList().map((proof) => proof.toObject()),
+                  response.getProofsList().map(
+                      (proof) => AssetProof.fromGRPCAssetProof(proof),
+                  ),
               );
 
               resolve(contractExecutionResult);
@@ -445,4 +447,5 @@ module.exports = {
   StatusCode,
   ContractExecutionResult,
   LedgerValidationResult,
+  AssetProof,
 };

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -20,7 +20,7 @@ class LedgerValidationResult {
   static fromGRPCLedgerValidationResponse(response) {
     return new LedgerValidationResult(
         response.getStatusCode(),
-        AssetProof.fromGRPCAssetProof(response.getProof()),
+        AssetProof.fromGrpcAssetProof(response.getProof()),
     );
   }
 
@@ -42,4 +42,3 @@ class LedgerValidationResult {
 module.exports = {
   LedgerValidationResult,
 };
-

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -17,7 +17,7 @@ class LedgerValidationResult {
    * @param {LedgerValidationResponse} response
    * @return {LedgerValidationResult}
    */
-  static fromGRPCLedgerValidationResponse(response) {
+  static fromGrpcLedgerValidationResponse(response) {
     return new LedgerValidationResult(
         response.getStatusCode(),
         AssetProof.fromGrpcAssetProof(response.getProof()),

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -14,7 +14,7 @@ class LedgerValidationResult {
   }
 
   /**
-   * @param {LedgerValidationResponse} response
+   * @param {proto.rpc.LedgerValidationResponse} response
    * @return {LedgerValidationResult}
    */
   static fromGrpcLedgerValidationResponse(response) {

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -1,7 +1,7 @@
 const {AssetProof} = require('./asset_proof');
 
 /**
- * To handle LedgerValidationResponse
+ * @public
  */
 class LedgerValidationResult {
   /**

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -1,0 +1,10 @@
+/**
+ * To handle LedgerValidationResponse
+ */
+class LedgerValidationResult {
+}
+
+module.exports = {
+  LedgerValidationResult,
+};
+

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -2,6 +2,28 @@
  * To handle LedgerValidationResponse
  */
 class LedgerValidationResult {
+  /**
+   * @param {StatusCode} code
+   * @param {AssetProof} proof
+   */
+  constructor(code, proof) {
+    this.code = code;
+    this.proof = proof;
+  }
+
+  /**
+   * @return {AssetProof}
+   */
+  getProof() {
+    return this.proof;
+  }
+
+  /**
+   * @return {StatusCode}
+   */
+  getCode() {
+    return this.code;
+  }
 }
 
 module.exports = {

--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -1,3 +1,5 @@
+const {AssetProof} = require('./asset_proof');
+
 /**
  * To handle LedgerValidationResponse
  */
@@ -9,6 +11,17 @@ class LedgerValidationResult {
   constructor(code, proof) {
     this.code = code;
     this.proof = proof;
+  }
+
+  /**
+   * @param {LedgerValidationResponse} response
+   * @return {LedgerValidationResult}
+   */
+  static fromGRPCLedgerValidationResponse(response) {
+    return new LedgerValidationResult(
+        response.getStatusCode(),
+        AssetProof.fromGRPCAssetProof(response.getProof()),
+    );
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.0.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/status_code.js
+++ b/status_code.js
@@ -1,6 +1,7 @@
 /**
  * A type used for various http status codes
  * @enum {number}
+ * @public
  */
 const StatusCode = {
   OK: 200,

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -12,10 +12,10 @@ const services = {
   'ledgerClient': {},
 };
 const clientProperties = {
-  'scalar.ledger.client.private_key_pem': 'key',
-  'scalar.ledger.client.cert_pem': 'cert',
-  'scalar.ledger.client.cert_holder_id': 'hold',
-  'scalar.ledger.client.cert_version': '1.0',
+  'scalar.dl.client.private_key_pem': 'key',
+  'scalar.dl.client.cert_pem': 'cert',
+  'scalar.dl.client.cert_holder_id': 'hold',
+  'scalar.dl.client.cert_version': '1.0',
 };
 
 describe('Class ClientServiceBase', () => {
@@ -24,9 +24,9 @@ describe('Class ClientServiceBase', () => {
       it('when the private key is missing', () => {
         // prepare
         const clientProperties = {
-          // "scalar.ledger.client.private_key_pem": "key",
-          'scalar.ledger.client.cert_pem': 'cert',
-          'scalar.ledger.client.cert_holder_id': 'hold',
+          // "scalar.dl.client.private_key_pem": "key",
+          'scalar.dl.client.cert_pem': 'cert',
+          'scalar.dl.client.cert_holder_id': 'hold',
         };
 
         // act assert
@@ -37,9 +37,9 @@ describe('Class ClientServiceBase', () => {
       it('when the certificate is missing', () => {
         // prepare
         const clientProperties = {
-          'scalar.ledger.client.private_key_pem': 'key',
-          // 'scalar.ledger.client.cert_pem': 'cert',
-          'scalar.ledger.client.cert_holder_id': 'hold',
+          'scalar.dl.client.private_key_pem': 'key',
+          // 'scalar.dl.client.cert_pem': 'cert',
+          'scalar.dl.client.cert_holder_id': 'hold',
         };
 
         // act assert
@@ -50,9 +50,9 @@ describe('Class ClientServiceBase', () => {
       it('when holder id is missing', () => {
         // prepare
         const clientProperties = {
-          'scalar.ledger.client.private_key_pem': 'key',
-          'scalar.ledger.client.cert_pem': 'cert',
-          // 'scalar.ledger.client.cert_holder_id': 'hold',
+          'scalar.dl.client.private_key_pem': 'key',
+          'scalar.dl.client.cert_pem': 'cert',
+          // 'scalar.dl.client.cert_holder_id': 'hold',
         };
 
         // act assert
@@ -65,11 +65,11 @@ describe('Class ClientServiceBase', () => {
         () => {
         // prepare
           const clientProperties = {
-            'scalar.ledger.client.private_key_pem': 'key',
-            'scalar.ledger.client.cert_pem': 'cert',
-            'scalar.ledger.client.cert_holder_id': 'hold',
-            'scalar.ledger.client.cert_version': '1.0',
-            'scalar.ledger.client.authorization.credential':
+            'scalar.dl.client.private_key_pem': 'key',
+            'scalar.dl.client.cert_pem': 'cert',
+            'scalar.dl.client.cert_holder_id': 'hold',
+            'scalar.dl.client.cert_version': '1.0',
+            'scalar.dl.client.authorization.credential':
             'mocked-credentials',
           };
 
@@ -147,11 +147,11 @@ describe('Class ClientServiceBase', () => {
 
         // assert
         assert(mockSpySetCertHolderId.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_holder_id']));
+            clientProperties['scalar.dl.client.cert_holder_id']));
         assert(mockSpySetCertVersion.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_version']));
+            clientProperties['scalar.dl.client.cert_version']));
         assert(mockSpySetCertPem.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_pem']));
+            clientProperties['scalar.dl.client.cert_pem']));
         assert.isUndefined(response);
       });
     });
@@ -328,9 +328,9 @@ describe('Class ClientServiceBase', () => {
         assert(mockSpySetContractProperties.calledWithExactly(
             mockedPropertiesJson));
         assert(mockSpySetCertHolderId.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_holder_id']));
+            clientProperties['scalar.dl.client.cert_holder_id']));
         assert(mockSpySetCertVersion.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_version']));
+            clientProperties['scalar.dl.client.cert_version']));
         assert(mockSpySetSignature.calledOnce);
         assert.isUndefined(response);
       });
@@ -390,9 +390,9 @@ describe('Class ClientServiceBase', () => {
         // assert
         assert(mockSpyContractsListingRequest.calledOnce);
         assert(mockSpySetCertHolderId.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_holder_id']));
+            clientProperties['scalar.dl.client.cert_holder_id']));
         assert(mockSpySetCertVersion.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_version']));
+            clientProperties['scalar.dl.client.cert_version']));
         assert(
             mockSpySetContractId.calledWithExactly(mockedContractId));
         assert(mockSpySetSignature.calledOnce);
@@ -452,9 +452,9 @@ describe('Class ClientServiceBase', () => {
         assert(mockSpyLedgerValidationRequest.calledOnce);
         assert(mockSpySetAssetId.calledWithExactly(mockedAssetId));
         assert(mockSpySetCertHolderId.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_holder_id']));
+            clientProperties['scalar.dl.client.cert_holder_id']));
         assert(mockSpySetCertVersion.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_version']));
+            clientProperties['scalar.dl.client.cert_version']));
         assert(mockSpySetSignature.calledOnce);
         assert.instanceOf(response, Object);
       });
@@ -534,9 +534,9 @@ describe('Class ClientServiceBase', () => {
         assert(mockSpySetContractArgument.calledWith(
             sinon.match(mockedArgument.mocked)));
         assert(mockSpySetCertHolderId.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_holder_id']));
+            clientProperties['scalar.dl.client.cert_holder_id']));
         assert(mockSpySetCertVersion.calledWithExactly(
-            clientProperties['scalar.ledger.client.cert_version']));
+            clientProperties['scalar.dl.client.cert_version']));
         assert(mockSpySetSignature.calledOnce);
         assert(mockSpySetFunctionArgument.calledWithExactly(
             mockedFunctionArgumentJson));

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -424,9 +424,16 @@ describe('Class ClientServiceBase', () => {
             {
               ledgerClient: {
                 validateLedger: (_, __, callback) => {
+                  const mockProof = {
+                    getAssetId: () => 'asset-id',
+                    getAge: () => 1,
+                    getHash_asU8: () => null,
+                    getNonce: () => 'nonce',
+                    getSignature_asU8: () => null,
+                  };
                   const mockedResponse = {
                     getStatusCode: () => 0,
-                    getProof: () => null,
+                    getProof: () => mockProof,
                   };
                   callback(null, mockedResponse);
                 },
@@ -494,9 +501,16 @@ describe('Class ClientServiceBase', () => {
             {
               ledgerClient: {
                 executeContract: (_, __, callback) => {
+                  const mockProof = {
+                    getAssetId: () => 'asset-id',
+                    getAge: () => 1,
+                    getHash_asU8: () => null,
+                    getNonce: () => 'nonce',
+                    getSignature_asU8: () => null,
+                  };
                   const mockedResponse = {
                     getResult: () => '',
-                    getProofsList: () => [],
+                    getProofsList: () => [mockProof],
                   };
                   callback(null, mockedResponse);
                 },

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -2,6 +2,7 @@ const {
   ClientServiceBase,
   StatusCode,
   ClientError,
+  ContractExecutionResult,
 } = require('..');
 
 const sinon = require('sinon');
@@ -492,9 +493,8 @@ describe('Class ClientServiceBase', () => {
               ledgerClient: {
                 executeContract: (_, __, callback) => {
                   const mockedResponse = {
-                    toObject: () => ({
-                      result: '{}',
-                    }),
+                    getResult: () => '',
+                    getProofsList: () => [],
                   };
                   callback(null, mockedResponse);
                 },
@@ -540,7 +540,8 @@ describe('Class ClientServiceBase', () => {
         assert(mockSpySetSignature.calledOnce);
         assert(mockSpySetFunctionArgument.calledWithExactly(
             mockedFunctionArgumentJson));
-        assert.instanceOf(response, Object);
+
+        assert.instanceOf(response, ContractExecutionResult);
       });
     });
     describe('_executePromise', () => {

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -3,6 +3,7 @@ const {
   StatusCode,
   ClientError,
   ContractExecutionResult,
+  LedgerValidationResult,
 } = require('..');
 
 const sinon = require('sinon');
@@ -424,7 +425,8 @@ describe('Class ClientServiceBase', () => {
               ledgerClient: {
                 validateLedger: (_, __, callback) => {
                   const mockedResponse = {
-                    toObject: () => ({}),
+                    getStatusCode: () => 0,
+                    getProof: () => null,
                   };
                   callback(null, mockedResponse);
                 },
@@ -457,7 +459,7 @@ describe('Class ClientServiceBase', () => {
         assert(mockSpySetCertVersion.calledWithExactly(
             clientProperties['scalar.dl.client.cert_version']));
         assert(mockSpySetSignature.calledOnce);
-        assert.instanceOf(response, Object);
+        assert.instanceOf(response, LedgerValidationResult);
       });
     });
     describe('executeContract', () => {


### PR DESCRIPTION
This PR is committing the following changes:
- Rename many Scalar DL properties
- Add ContractExecutionResult class
- Add LedgerValidationResult class
- Add AssetProof class