### PR TITLE
Handle as proto.rpc.LedgerValidationResponse.getProof() returns null

### DIFF
--- a/ledger_validation_result.js
+++ b/ledger_validation_result.js
@@ -20,7 +20,9 @@ class LedgerValidationResult {
   static fromGrpcLedgerValidationResponse(response) {
     return new LedgerValidationResult(
         response.getStatusCode(),
-        AssetProof.fromGrpcAssetProof(response.getProof()),
+        response.getProof()
+          ? AssetProof.fromGrpcAssetProof(response.getProof())
+          : null,
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
The definition of `proto.rpc.LedgerValidationResponse.getProof()` is

```
/**
 * optional AssetProof proof = 2;
 * @return {?proto.rpc.AssetProof}
 */
proto.rpc.LedgerValidationResponse.prototype.getProof = function() {
    ...
}
```
It is optional and might return `null`.
We have to handle it.