### PR TITLE
Exported builder and update version to 2.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class ClientServiceBase {
         'scalar.dl.client.cert_holder_id');
     /** @const */
     this.credential =
-      properties['scalar.dl.client.authorization.credential'];
+        properties['scalar.dl.client.authorization.credential'];
     /** @const */
     this.certVersion = properties['scalar.dl.client.cert_version'];
 
@@ -121,8 +121,8 @@ class ClientServiceBase {
     const builder = new CertificateRegistrationRequestBuilder(
         new this.protobuf.CertificateRegistrationRequest(),
     ).withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion)
-        .withCertPem(this.certPem);
+    .withCertVersion(this.certVersion)
+    .withCertPem(this.certPem);
 
     const request = await builder.build();
     const promise = new Promise((resolve, reject) => {
@@ -160,8 +160,8 @@ class ClientServiceBase {
     const builder = new FunctionRegistrationRequestBuilder(
         new this.protobuf.FunctionRegistrationRequest(),
     ).withFunctionId(id)
-        .withFunctionBinaryName(name)
-        .withFunctionByteCode(functionBytes);
+    .withFunctionBinaryName(name)
+    .withFunctionByteCode(functionBytes);
 
     const request = await builder.build();
     const promise = new Promise((resolve, reject) => {
@@ -204,11 +204,11 @@ class ClientServiceBase {
         new this.protobuf.ContractRegistrationRequest(),
         this.signer,
     ).withContractId(id)
-        .withContractBinaryName(name)
-        .withContractByteCode(contractBytes)
-        .withContractProperties(propertiesJson)
-        .withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion);
+    .withContractBinaryName(name)
+    .withContractByteCode(contractBytes)
+    .withContractProperties(propertiesJson)
+    .withCertHolderId(this.certHolderId)
+    .withCertVersion(this.certVersion);
 
     let request;
     try {
@@ -249,8 +249,8 @@ class ClientServiceBase {
         new this.protobuf.ContractsListingRequest(),
         this.signer,
     ).withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion)
-        .withContractId(contractId);
+    .withCertVersion(this.certVersion)
+    .withContractId(contractId);
 
     let request;
     try {
@@ -290,8 +290,8 @@ class ClientServiceBase {
         new this.protobuf.LedgerValidationRequest(),
         this.signer,
     ).withAssetId(assetId)
-        .withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion);
+    .withCertHolderId(this.certHolderId)
+    .withCertVersion(this.certVersion);
 
     let request;
     try {
@@ -340,10 +340,10 @@ class ClientServiceBase {
         new this.protobuf.ContractExecutionRequest(),
         this.signer,
     ).withContractId(contractId)
-        .withContractArgument(argumentJson)
-        .withFunctionArgument(functionArgumentJson)
-        .withCertHolderId(this.certHolderId)
-        .withCertVersion(this.certVersion);
+    .withContractArgument(argumentJson)
+    .withFunctionArgument(functionArgumentJson)
+    .withCertHolderId(this.certHolderId)
+    .withCertVersion(this.certVersion);
 
     let request;
     try {
@@ -438,4 +438,10 @@ module.exports = {
   ContractExecutionResult,
   LedgerValidationResult,
   AssetProof,
+  CertificateRegistrationRequestBuilder,
+  FunctionRegistrationRequestBuilder,
+  ContractRegistrationRequestBuilder,
+  ContractsListingRequestBuilder,
+  LedgerValidationRequestBuilder,
+  ContractExecutionRequestBuilder,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.2.2",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.3.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.3.2",
+  "version": "2.3.0",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.2.2",
+  "version": "2.3.2",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
This PR will export all the request builders and have a minor version update. This is the first part of the upgrade implementation proposed [here](https://docs.google.com/document/d/1wWcb6N9L8E35RHVNMcQMSeVbSwmPqNqaJByc2BoejyI/edit#heading=h.b4tbvqiasw7z) for more information...