### PR TITLE
Set contract properties to be optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/request/builder.js
+++ b/request/builder.js
@@ -265,7 +265,7 @@ class ContractRegistrationRequestBuilder {
     validator.validateInput(this.contractId, String);
     validator.validateInput(this.contractBinaryName, String);
     validator.validateInput(this.contractByteCode, Uint8Array);
-    validator.validateInput(this.contractProperties, String);
+    validator.validateInput(this.contractProperties, String, true);
     validator.validateInput(this.certHolderId, String);
     validator.validateInput(this.certVersion, Number);
 


### PR DESCRIPTION
When registering contracts, contract properties should be optional. This patch fixes it.