### PR TITLE
Remove the validation on client's key, certificate and holder ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,14 +43,11 @@ class ClientServiceBase {
       );
     }
     /** @const */
-    this.privateKeyPem = this._getRequiredProperty(properties,
-        'scalar.dl.client.private_key_pem');
+    this.privateKeyPem = properties['scalar.dl.client.private_key_pem'];
     /** @const */
-    this.certPem = this._getRequiredProperty(properties,
-        'scalar.dl.client.cert_pem');
+    this.certPem = properties['scalar.dl.client.cert_pem'];
     /** @const */
-    this.certHolderId = this._getRequiredProperty(properties,
-        'scalar.dl.client.cert_holder_id');
+    this.certHolderId = properties['scalar.dl.client.cert_holder_id'];
     /** @const */
     this.credential =
       properties['scalar.dl.client.authorization.credential'];
@@ -95,22 +92,6 @@ class ClientServiceBase {
    */
   static get binaryStatusKey() {
     return 'rpc.status-bin';
-  }
-
-  /**
-   * @param {Object} properties JSON Object used for setting client properties
-   * @param {string} name the name of the property to get
-   * @return {Object} The client property specified in the @name parameter
-   */
-  _getRequiredProperty(properties, name) {
-    const value = properties[name];
-    if (!value) {
-      throw new ClientError(
-          StatusCode.CLIENT_IO_ERROR,
-          `property '${name}' is required`,
-      );
-    }
-    return value;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -22,47 +22,6 @@ const clientProperties = {
 
 describe('Class ClientServiceBase', () => {
   describe('The constructor', () => {
-    describe('should throw an error', () => {
-      it('when the private key is missing', () => {
-        // prepare
-        const clientProperties = {
-          // "scalar.dl.client.private_key_pem": "key",
-          'scalar.dl.client.cert_pem': 'cert',
-          'scalar.dl.client.cert_holder_id': 'hold',
-        };
-
-        // act assert
-        assert.throws(() => {
-          new ClientServiceBase(services, protobuf, clientProperties);
-        }, ClientError, 'private_key_pem');
-      });
-      it('when the certificate is missing', () => {
-        // prepare
-        const clientProperties = {
-          'scalar.dl.client.private_key_pem': 'key',
-          // 'scalar.dl.client.cert_pem': 'cert',
-          'scalar.dl.client.cert_holder_id': 'hold',
-        };
-
-        // act assert
-        assert.throws(() => {
-          new ClientServiceBase(services, protobuf, clientProperties);
-        }, ClientError, 'cert_pem');
-      });
-      it('when holder id is missing', () => {
-        // prepare
-        const clientProperties = {
-          'scalar.dl.client.private_key_pem': 'key',
-          'scalar.dl.client.cert_pem': 'cert',
-          // 'scalar.dl.client.cert_holder_id': 'hold',
-        };
-
-        // act assert
-        assert.throws(() => {
-          new ClientServiceBase(services, protobuf, clientProperties);
-        }, ClientError, 'cert_holder_id');
-      });
-    });
     it('should properly load the attribute according to the given property',
         () => {
         // prepare


### PR DESCRIPTION
In the constructor on ClientServiceBase, we check the existence of the client's key, certificate and holder ID in properties. However, ClientServiceBase can be used in ClientServiceWithBinary. It is for the server-side application development in which we don't need to pass the client's key, certificate and holder ID.