### PR TITLE
Fix nonce generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const {ContractExecutionResult} = require('./contract_execution_result');
 const {LedgerValidationResult} = require('./ledger_validation_result');
 const {AssetProof} = require('./asset_proof');
 
+const {v4: uuidv4} = require('uuid');
+
 /**
  * This class handles all client interactions including registering certificates
  * and contracts, listing contracts, validating the ledger, and executing
@@ -577,7 +579,7 @@ class ClientServiceBase {
         ],
     );
 
-    argument['nonce'] = new Date().getTime().toString();
+    argument['nonce'] = uuidv4();
     const argumentJson = JSON.stringify(argument);
     const functionArgumentJson = JSON.stringify(functionArgument);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,6 +1443,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
         }
       }
     },
@@ -1920,10 +1926,9 @@
       }
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "ajv": "^6.12.6",
-    "jsrsasign": "^10.0.4"
+    "jsrsasign": "^10.0.4",
+    "uuid": "^8.3.2"
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",


### PR DESCRIPTION
The nonce parameter in ContractExecutionRequest must be generated as a UUID instead of a timestamp to prevent it from conflicting. This patch fixes it.