### PR TITLE
Add unnecessary files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 README.md
 README.png
+.circleci/
+.eslintrc.json
+test/


### PR DESCRIPTION
This PR adds some files to `.npmignore` to avoid publishing them to the NPM registry.