### PR TITLE
Fix UnhandledPromiseRejectionWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,8 @@ class ClientServiceBase {
    * @throws {ClientError|Error}
    */
   async _registerCertificate(request) {
+    await this._registerToAuditorCertificate(request);
+
     const promise = new Promise((resolve, reject) => {
       this.ledgerPrivileged.registerCert(
           request,
@@ -135,7 +137,6 @@ class ClientServiceBase {
       );
     });
 
-    await this._registerToAuditorCertificate(request);
     return this._executePromise(promise);
   }
 
@@ -226,6 +227,8 @@ class ClientServiceBase {
    * @throws {ClientError|Error}
    */
   async _registerContract(request) {
+    await this._registerToAuditorContract(request);
+
     const promise = new Promise((resolve, reject) => {
       this.ledgerClient.registerContract(
           request,
@@ -240,7 +243,6 @@ class ClientServiceBase {
       );
     });
 
-    await this._registerToAuditorContract(request);
     return this._executePromise(promise);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
This PR fixes `UnhandledPromiseRejectionWarning` from the `registerCert` and `registerContract` functions.

This warning does impact the package but UnhandledPromiseRejectionWarning is a deprecated feature in node runtime in the future.

It is caused by, when we `await` a promise A after a promise B is created in an async function, if promise A throws an exception, then the promise B will remain unhandled.

We can easily create promise B after promise A is done to fix this issue.