### PR TITLE
Support optional properties with default values

### DIFF
--- a/client_properties.js
+++ b/client_properties.js
@@ -71,6 +71,26 @@ defaultSchema.properties[ClientPropertiesField.AUTHORIZATION_CREDENTIAL] = {
 };
 
 /**
+ * Return a properties object with default values for optinal properties
+ * @return {Object}
+ */
+function defaultProperties() {
+  const properties = {};
+
+  properties[ClientPropertiesField.SERVER_HOST] = 'localhost';
+  properties[ClientPropertiesField.SERVER_PORT] = 50051;
+  properties[ClientPropertiesField.SERVER_PRIVILEGED_PORT] = 50052;
+  properties[ClientPropertiesField.CERT_VERSION] = 1;
+  properties[ClientPropertiesField.TLS_ENABLED] = false;
+  properties[ClientPropertiesField.AUDITOR_ENABLED] = false;
+  properties[ClientPropertiesField.AUDITOR_HOST] = 'localhost';
+  properties[ClientPropertiesField.AUDITOR_PORT] = 40051;
+  properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT] = 40052;
+
+  return properties;
+}
+
+/**
  * A class represents client properties object
  */
 class ClientProperties {
@@ -80,6 +100,11 @@ class ClientProperties {
    * @param {Array} oneOf array of string. required properties
    */
   constructor(properties, allOf, oneOf) {
+    properties = {
+      ...defaultProperties(),
+      ...properties, // this object overwrites the upper default properties
+    };
+
     allOf = allOf || [];
     oneOf = oneOf || [];
 

--- a/test/client_properties.test.js
+++ b/test/client_properties.test.js
@@ -35,15 +35,7 @@ describe('ClientProperties', () => {
 
   it('should throw errors when any property of allOf is not provided', () => {
     expect(() => {
-      new ClientProperties(
-          {
-            'scalar.dl.client.cert_holder_id': 'foo',
-          },
-          [
-            ClientPropertiesField.CERT_HOLDER_ID,
-            ClientPropertiesField.CERT_VERSION,
-          ],
-      );
+      new ClientProperties({}, [ClientPropertiesField.CERT_HOLDER_ID]);
     }).to.throw(Error);
   });
 
@@ -55,7 +47,7 @@ describe('ClientProperties', () => {
         null,
         [
           ClientPropertiesField.CERT_HOLDER_ID,
-          ClientPropertiesField.CERT_VERSION,
+          ClientPropertiesField.CERT_PEM,
         ],
     );
     assert.equal('foo', properties.getCertHolderId());
@@ -116,5 +108,43 @@ describe('ClientProperties', () => {
           ClientPropertiesField.PRIVATE_KEY_CRYPTOKEY,
         ], // oneOf
     )).to.throw(Error);
+  });
+
+  it('should set optional properties with default values', () => {
+    const properties = new ClientProperties({}, [], []);
+
+    assert.equal('localhost', properties.getServerHost());
+    assert.equal(50051, properties.getServerPort());
+    assert.equal(50052, properties.getServerPrivilegedPort());
+    assert.equal('localhost', properties.getAuditorHost());
+    assert.equal(40051, properties.getAuditorPort());
+    assert.equal(40052, properties.getAuditorPrivilegedPort());
+    assert.equal(1, properties.getCertVersion());
+    assert.equal(false, properties.getTlsEnabled());
+    assert.equal(false, properties.getAuditorEnabled());
+  });
+
+  it('should overwrite default values of default properties', () => {
+    const properties = new ClientProperties({
+      'scalar.dl.client.server.host': 'ledger.example.com',
+      'scalar.dl.client.server.port': 80,
+      'scalar.dl.client.server.privileged_port': 8080,
+      'scalar.dl.client.auditor.host': 'auditor.example.com',
+      'scalar.dl.client.auditor.port': 443,
+      'scalar.dl.client.auditor.privileged_port': 4433,
+      'scalar.dl.client.cert_version': 10,
+      'scalar.dl.client.tls.enabled': true,
+      'scalar.dl.client.auditor.enabled': true,
+    }, [], []);
+
+    assert.equal('ledger.example.com', properties.getServerHost());
+    assert.equal(80, properties.getServerPort());
+    assert.equal(8080, properties.getServerPrivilegedPort());
+    assert.equal('auditor.example.com', properties.getAuditorHost());
+    assert.equal(443, properties.getAuditorPort());
+    assert.equal(4433, properties.getAuditorPrivilegedPort());
+    assert.equal(10, properties.getCertVersion());
+    assert.equal(true, properties.getTlsEnabled());
+    assert.equal(true, properties.getAuditorEnabled());
   });
 });


### PR DESCRIPTION
This PR revised ClientProperties class to set default values to optional properties if they are not configured.