### PR TITLE
Implement linearizable ledger validation

### DIFF
--- a/client_properties.js
+++ b/client_properties.js
@@ -14,6 +14,10 @@ const ClientPropertiesField = {
   AUDITOR_HOST: 'scalar.dl.client.auditor.host',
   AUDITOR_PORT: 'scalar.dl.client.auditor.port',
   AUDITOR_PRIVILEGED_PORT: 'scalar.dl.client.auditor.privileged_port',
+  AUDITOR_LINEARIZABLE_VALIDATION_ENABLED:
+    'scalar.dl.client.auditor.linearizable_validation.enabled',
+  AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID:
+    'scalar.dl.client.auditor.linearizable_validation.contract_id',
   TLS_CA_ROOT_CERT_PEM: 'scalar.dl.client.tls.ca_root_cert_pem',
   TLS_ENABLED: 'scalar.dl.client.tls.enabled',
   AUTHORIZATION_CREDENTIAL: 'scalar.dl.client.authorization.credential',
@@ -60,6 +64,16 @@ defaultSchema.properties[ClientPropertiesField.AUDITOR_PORT] = {
 defaultSchema.properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT] = {
   'type': 'number',
 };
+defaultSchema.properties[
+    ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
+] = {
+  type: 'boolean',
+};
+defaultSchema.properties[
+    ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
+] = {
+  type: 'string',
+};
 defaultSchema.properties[ClientPropertiesField.TLS_CA_ROOT_CERT_PEM] = {
   'type': 'string',
 };
@@ -86,6 +100,12 @@ function defaultProperties() {
   properties[ClientPropertiesField.AUDITOR_HOST] = 'localhost';
   properties[ClientPropertiesField.AUDITOR_PORT] = 40051;
   properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT] = 40052;
+  properties[
+      ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
+  ] = false;
+  properties[
+      ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
+  ] = 'validate-ledger';
 
   return properties;
 }
@@ -100,8 +120,10 @@ class ClientProperties {
    * @param {Array} oneOf array of string. required properties
    */
   constructor(properties, allOf, oneOf) {
+    const theDefaultProperties = defaultProperties();
+
     properties = {
-      ...defaultProperties(),
+      ...theDefaultProperties,
       ...properties, // this object overwrites the upper default properties
     };
 
@@ -127,6 +149,21 @@ class ClientProperties {
               'In the client properties:',
           ),
       );
+    }
+
+    if (properties[ClientPropertiesField.AUDITOR_ENABLED] !== true) {
+      properties[
+          ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
+      ] =
+        theDefaultProperties[
+            ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
+        ];
+      properties[
+          ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
+      ] =
+        theDefaultProperties[
+            ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
+        ];
     }
 
     this.properties = properties;
@@ -214,6 +251,24 @@ class ClientProperties {
    */
   getAuditorPrivilegedPort() {
     return this.properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT];
+  }
+
+  /**
+   * @return {Boolean}
+   */
+  getAuditorLinearizableValidationEnabled() {
+    return this.properties[
+        ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
+    ];
+  }
+
+  /**
+   * @return {String}
+   */
+  getAuditorLinearizableValidationContractId() {
+    return this.properties[
+        ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
+    ];
   }
 
   /**

--- a/contract_execution_result.js
+++ b/contract_execution_result.js
@@ -7,10 +7,12 @@ class ContractExecutionResult {
   /**
    * @param {Object} result
    * @param {Array} proofs
+   * @param {Array} [auditorProofs = []]
    */
-  constructor(result, proofs) {
+  constructor(result, proofs, auditorProofs = []) {
     this.result = result;
     this.proofs = proofs;
+    this.auditorProofs = auditorProofs;
   }
 
   /**
@@ -42,6 +44,13 @@ class ContractExecutionResult {
    */
   getProofs() {
     return this.proofs;
+  }
+
+  /**
+   * @return {Array}
+   */
+  getAuditorProofs() {
+    return this.auditorProofs;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "@scalar-labs/scalardl-javascript-sdk-base",
   "repository": "https://github.com/scalar-labs/scalardl-javascript-sdk-base",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "This package is the base of Scalar DL JavaScript SDK. You probably don't really need to use this package directly. Check @scalar-labs/scalardl-web-client-sdk.",
   "author": "Scalar, Inc.",
   "license": "AGPL-3.0-or-later",

--- a/test/client_properties.test.js
+++ b/test/client_properties.test.js
@@ -147,4 +147,52 @@ describe('ClientProperties', () => {
     assert.equal(true, properties.getTlsEnabled());
     assert.equal(true, properties.getAuditorEnabled());
   });
+
+  it('should have default linearizable properties', () => {
+    const properties = new ClientProperties({}, [], []);
+    assert.equal(false, properties.getAuditorLinearizableValidationEnabled());
+    assert.equal(
+        'validate-ledger',
+        properties.getAuditorLinearizableValidationContractId(),
+    );
+  });
+
+  it(
+      'should be able to configure linearizable properties in auditor mode',
+      () => {
+        const properties = new ClientProperties({
+          'scalar.dl.client.auditor.enabled': true,
+          'scalar.dl.client.auditor.linearizable_validation.enabled': true,
+          'scalar.dl.client.auditor.linearizable_validation.contract_id': 'foo',
+        }, [], []);
+        assert.equal(
+            true,
+            properties.getAuditorLinearizableValidationEnabled(),
+        );
+        assert.equal(
+            'foo',
+            properties.getAuditorLinearizableValidationContractId(),
+        );
+      },
+  );
+
+  it(
+      'should not be able to configure linearizable properties ' +
+      'if it is not in auditor mode',
+      () => {
+        const properties = new ClientProperties({
+          'scalar.dl.client.auditor.enabled': false,
+          'scalar.dl.client.auditor.linearizable_validation.enabled': true,
+          'scalar.dl.client.auditor.linearizable_validation.contract_id': 'foo',
+        }, [], []);
+        assert.equal(
+            false,
+            properties.getAuditorLinearizableValidationEnabled(),
+        );
+        assert.equal(
+            'validate-ledger',
+            properties.getAuditorLinearizableValidationContractId(),
+        );
+      },
+  );
 });


### PR DESCRIPTION
This PR implements linearizable ledger validation.

It also re-implemented the internal function `_executeValidation`.
It is now renamed as `_validateExecution`.
The original return is a boolean type result that denotes if the auditor's contract execution result is consistent with the ledger's. However, because we need the auditor's asset proof, so this PR made a bit of revision to return the auditor's contract execution result and confirm the consistency in the caller function.
Sorry for the change.