### PR TITLE
Revise README.md. Generate Proto Buffers files for @grpc/grpc-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Make sure in the code that the ClientServiceBase has been initialized correctly.
 Make sure you have installed [grpc-tools](https://www.npmjs.com/package/grpc-tools) (global installation recommended). Then, go to the folder containing scalar.proto and execute the command:
 
 ```
-grpc_tools_node_protoc --js_out=import_style=commonjs,binary:. --grpc_out=. --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` scalar.proto
+grpc_tools_node_protoc --js_out=import_style=commonjs,binary:. --grpc_out=grpc_js:. --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` scalar.proto
 ```
 
 *Note: If you install grpc-tools locally, you will need to modify the above command to manually include the path of the grpc tools in the node_modules folder.


### PR DESCRIPTION
This PR revises README.md to update the command of generating the Proto Buffers files for the Node Client SDK.

The reason for doing that is:
The previous command generates files for the JavaScript `grpc` package but the package is deprecated and replaced by the `@grpc/grpc-js` package.
Scalar DL Node Client SDK will also updates its dependency (in https://github.com/scalar-labs/scalardl-node-client-sdk/pull/76) to use `@grpc/grpc-js` so the generation command needs to be revised here.