### PR TITLE
Abstract TextEncoder as a polyfill

### DIFF
--- a/polyfill/text_encoder.js
+++ b/polyfill/text_encoder.js
@@ -1,0 +1,23 @@
+const jsrsasign = require('jsrsasign');
+
+/**
+ * An internal class to encode utf8 string to Uint8Array
+ * @class
+ */
+class TextEncoder {
+  /**
+   * To encode utf8 to Uint8Array
+   * @param {string} string
+   * @return {Uint8Array}
+   */
+  encode(string) {
+    return !string ?
+        new Uint8Array() :
+        new Uint8Array(
+            jsrsasign.hextoArrayBuffer(jsrsasign.utf8tohex(string)));
+  }
+}
+
+module.exports = {
+  TextEncoder,
+};

--- a/request/builder.js
+++ b/request/builder.js
@@ -1,22 +1,4 @@
-const jsrsasign = require('jsrsasign');
-
-/**
- * An internal class to encode utf8 string to Uint8Array
- * @class
- */
-class TextEncoder {
-  /**
-   * To encode utf8 to Uint8Array
-   * @param {string} string
-   * @return {Uint8Array}
-   */
-  encode(string) {
-    return !string ?
-        new Uint8Array() :
-        new Uint8Array(
-            jsrsasign.hextoArrayBuffer(jsrsasign.utf8tohex(string)));
-  }
-}
+const {TextEncoder} = require('../polyfill/text_encoder');
 
 /**
  * An internal class to validate input
@@ -33,14 +15,15 @@ class Validator {
       return;
     }
 
-    if (type.name === 'Uint8Array' && (input instanceof Uint8Array)) {
+    if (type.name === 'Uint8Array' && input instanceof Uint8Array) {
       return;
     }
 
-    if (typeof input === 'undefined' ||
-        input === null ||
-        input.constructor !== type ||
-        (input.constructor === Number && input < 0)
+    if (
+      typeof input === 'undefined' ||
+      input === null ||
+      input.constructor !== type ||
+      (input.constructor === Number && input < 0)
     ) {
       throw new Error('Specified argument is illegal.');
     }
@@ -279,19 +262,25 @@ class ContractRegistrationRequestBuilder {
 
     const contractId = new TextEncoder('utf-8').encode(this.contractId);
     const contractBinaryName = new TextEncoder('utf-8').encode(
-        this.contractBinaryName);
+        this.contractBinaryName,
+    );
     const contractBytes = this.contractByteCode;
     const contractProperties = new TextEncoder('utf-8').encode(
-        this.contractProperties);
+        this.contractProperties,
+    );
     const certHolderId = new TextEncoder('utf-8').encode(this.certHolderId);
     const view = new DataView(new ArrayBuffer(4));
     view.setUint32(0, this.certVersion);
     const certVersion = new Uint8Array(view.buffer);
 
     const buffer = new Uint8Array(
-        contractId.byteLength + contractBinaryName.byteLength +
-        contractBytes.byteLength + contractProperties.byteLength +
-        certHolderId.byteLength + certVersion.byteLength);
+        contractId.byteLength +
+        contractBinaryName.byteLength +
+        contractBytes.byteLength +
+        contractProperties.byteLength +
+        certHolderId.byteLength +
+        certVersion.byteLength,
+    );
 
     let offset = 0;
     buffer.set(contractId, offset);
@@ -382,8 +371,10 @@ class ContractsListingRequestBuilder {
     const contractIdEncoded = new TextEncoder('utf-8').encode(this.contractId);
 
     const buffer = new Uint8Array(
-        contractIdEncoded.byteLength + certHolderId.byteLength +
-        certVersion.byteLength);
+        contractIdEncoded.byteLength +
+        certHolderId.byteLength +
+        certVersion.byteLength,
+    );
     let offset = 0;
 
     buffer.set(contractIdEncoded, offset);
@@ -502,7 +493,8 @@ class LedgerValidationRequestBuilder {
         startAge.byteLength +
         endAge.byteLength +
         certHolderId.byteLength +
-        certVersion.byteLength);
+        certVersion.byteLength,
+    );
     let offset = 0;
     buffer.set(assetId_, offset);
     offset += assetId_.byteLength;
@@ -610,15 +602,19 @@ class ContractExecutionRequestBuilder {
 
     const contractIdEncoded = new TextEncoder('utf-8').encode(this.contractId);
     const contractArgument = new TextEncoder('utf-8').encode(
-        this.contractArgument);
+        this.contractArgument,
+    );
     const certHolderId = new TextEncoder('utf-8').encode(this.certHolderId);
     const view = new DataView(new ArrayBuffer(4));
     view.setUint32(0, this.certVersion);
     const certVersion = new Uint8Array(view.buffer);
 
     const buffer = new Uint8Array(
-        contractIdEncoded.byteLength + contractArgument.byteLength +
-        certHolderId.byteLength + certVersion.byteLength);
+        contractIdEncoded.byteLength +
+        contractArgument.byteLength +
+        certHolderId.byteLength +
+        certVersion.byteLength,
+    );
     let offset = 0;
     buffer.set(contractIdEncoded, offset);
     offset += contractIdEncoded.byteLength;

--- a/test/text_encoder.test.js
+++ b/test/text_encoder.test.js
@@ -1,0 +1,19 @@
+const {TextEncoder} = require('../polyfill/text_encoder.js');
+
+test('if TextEncoder can encode the `hello world` string', () => {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode('hello world');
+
+  expect(encoded).toEqual(
+      new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+  );
+});
+
+test('if TextEncoder can encode the empty string', () => {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode('');
+
+  expect(encoded).toEqual(
+      new Uint8Array(),
+  );
+});


### PR DESCRIPTION
This PR abstracts the `TextEncoder` to a single utility. `TextEncoder` is polyfill to convert strings into Uint8Array(). I did this because it's used by the other file too.
