### PR TITLE
Add useFunctionIds and functionIds fields

### DIFF
--- a/request/builder.js
+++ b/request/builder.js
@@ -524,6 +524,9 @@ class ContractExecutionRequestBuilder {
   constructor(request, signer) {
     this.request = request;
     this.signer = signer;
+
+    this.useFunctionIds = false;
+    this.functionIds = [];
   }
 
   /**
@@ -581,6 +584,24 @@ class ContractExecutionRequestBuilder {
   }
 
   /**
+   * @param {boolean} useFunctionIds
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withUseFunctionIds(useFunctionIds) {
+    this.useFunctionIds = useFunctionIds;
+    return this;
+  }
+
+  /**
+   * @param {string[]} functionIds
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withFunctionIds(functionIds) {
+    this.functionIds = functionIds;
+    return this;
+  }
+
+  /**
    * Builds the ContractExecutionRequest
    * @throws {Error}
    * @return {ContractExecutionRequest}
@@ -592,6 +613,7 @@ class ContractExecutionRequestBuilder {
     validator.validateInput(this.certHolderId, String);
     validator.validateInput(this.certVersion, Number);
     validator.validateInput(this.functionArgument, String, true);
+    validator.validateInput(this.useFunctionIds, Boolean);
 
     const request = this.request;
     request.setContractId(this.contractId);
@@ -599,6 +621,8 @@ class ContractExecutionRequestBuilder {
     request.setCertHolderId(this.certHolderId);
     request.setCertVersion(this.certVersion);
     request.setFunctionArgument(this.functionArgument);
+    request.setUseFunctionIds(this.useFunctionIds);
+    request.setFunctionIdsList(this.functionIds);
 
     const contractIdEncoded = new TextEncoder('utf-8').encode(this.contractId);
     const contractArgument = new TextEncoder('utf-8').encode(

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -567,6 +567,8 @@ describe('executeContract', () => {
       setCertVersion: function() {},
       setFunctionArgument: function() {},
       setSignature: function() {},
+      setUseFunctionIds: function() {},
+      setFunctionIdsList: function() {},
     };
     const mockedProtobuf = {
       ContractExecutionRequest: function() {
@@ -778,6 +780,8 @@ describe('validateLedger linearizably', () => {
         setFunctionArgument: function() {},
         setSignature: function() {},
         setAuditorSignature: function() {},
+        setUseFunctionIds: function() {},
+        setFunctionIdsList: function() {},
       }),
       ExecutionValidationRequest: () => ({
         setRequest: function() {},


### PR DESCRIPTION
This PR adds two new properties (`use_function_ids` and `function_ids`) to the request payload in https://github.com/scalar-labs/scalar/blob/master/rpc/src/main/proto/scalar.proto#L93
The function execution in Scalar DL 3.5 doesn't rely on using `_functions_` in the contract argument anymore.