### PR TITLE
Contract Execution Argument

### DIFF
--- a/contract_execution_argument.js
+++ b/contract_execution_argument.js
@@ -24,47 +24,6 @@ function format(argument, nonce, functionIds) {
   }`;
 }
 
-/**
- * @param {Object} argument
- * @param {string} nonce
- * @return {string}
- */
-function formatDeprecated(argument, nonce) {
-  if (typeof argument !== 'object') {
-    throw new Error('argument must be an object');
-  }
-
-  if (typeof nonce !== 'string') {
-    throw new Error('nonce must be a string');
-  }
-
-  argument['nonce'] = nonce;
-
-  return JSON.stringify(argument);
-}
-
-/**
- * @param {Object} argument
- * @return {string[]}
- */
-function getFunctionIds(argument) {
-  if (typeof argument !== 'object') {
-    throw new Error('argument must be an object');
-  }
-
-  if (!argument.hasOwnProperty('_functions_')) {
-    return [];
-  }
-
-  if (!Array.isArray(argument['_functions_'])) {
-    throw new Error('argument._functions_ must be an array');
-  }
-
-  return argument['_functions_'];
-}
-
 module.exports = {
   format,
-  formatDeprecated,
-  getFunctionIds,
 };

--- a/contract_execution_argument.js
+++ b/contract_execution_argument.js
@@ -5,12 +5,12 @@ const FUNCTION_SEPARATOR = '\u0002';
 const ARGUMENT_SEPARATOR = '\u0003';
 
 /**
- * @param {string|Object} argument
  * @param {string} nonce
  * @param {string[]} functionIds
+ * @param {string|Object} argument
  * @return {string}
  */
-function format(argument, nonce, functionIds) {
+function format(nonce, functionIds, argument) {
   if (typeof argument !== 'string' && typeof argument !== 'object') {
     throw new Error('argument must be a string or an object');
   }

--- a/contract_execution_argument.js
+++ b/contract_execution_argument.js
@@ -1,0 +1,70 @@
+/**
+ * @param {string|Object} argument
+ * @param {string} nonce
+ * @param {string[]} functionIds
+ * @return {string}
+ */
+function format(argument, nonce, functionIds) {
+  if (typeof argument !== 'string' && typeof argument !== 'object') {
+    throw new Error('argument must be a string or an object');
+  }
+
+  if (typeof nonce !== 'string') {
+    throw new Error('nonce must be a string');
+  }
+
+  if (!Array.isArray(functionIds)) {
+    throw new Error('functionIds must be an array');
+  }
+
+  return `V2\u0001${nonce}\u0003${functionIds
+      .filter((v) => typeof v === 'string')
+      .join('\u0002')}\u0003${
+    typeof argument === 'object' ? JSON.stringify(argument) : argument
+  }`;
+}
+
+/**
+ * @param {Object} argument
+ * @param {string} nonce
+ * @return {string}
+ */
+function formatDeprecated(argument, nonce) {
+  if (typeof argument !== 'object') {
+    throw new Error('argument must be an object');
+  }
+
+  if (typeof nonce !== 'string') {
+    throw new Error('nonce must be a string');
+  }
+
+  argument['nonce'] = nonce;
+
+  return JSON.stringify(argument);
+}
+
+/**
+ * @param {Object} argument
+ * @return {string[]}
+ */
+function getFunctionIds(argument) {
+  if (typeof argument !== 'object') {
+    throw new Error('argument must be an object');
+  }
+
+  if (!argument.hasOwnProperty('_functions_')) {
+    return [];
+  }
+
+  if (!Array.isArray(argument['_functions_'])) {
+    throw new Error('argument._functions_ must be an array');
+  }
+
+  return argument['_functions_'];
+}
+
+module.exports = {
+  format,
+  formatDeprecated,
+  getFunctionIds,
+};

--- a/contract_execution_argument.js
+++ b/contract_execution_argument.js
@@ -1,3 +1,9 @@
+const ARGUMENT_VERSION_PREFIX = 'V';
+const ARGUMENT_FORMAT_VERSION = '2';
+const NONCE_SEPARATOR = '\u0001';
+const FUNCTION_SEPARATOR = '\u0002';
+const ARGUMENT_SEPARATOR = '\u0003';
+
 /**
  * @param {string|Object} argument
  * @param {string} nonce
@@ -17,11 +23,18 @@ function format(argument, nonce, functionIds) {
     throw new Error('functionIds must be an array');
   }
 
-  return `V2\u0001${nonce}\u0003${functionIds
-      .filter((v) => typeof v === 'string')
-      .join('\u0002')}\u0003${
-    typeof argument === 'object' ? JSON.stringify(argument) : argument
-  }`;
+  return (
+    ARGUMENT_VERSION_PREFIX +
+    ARGUMENT_FORMAT_VERSION +
+    NONCE_SEPARATOR +
+    nonce +
+    ARGUMENT_SEPARATOR +
+    `${functionIds
+        .filter((v) => typeof v === 'string')
+        .join(FUNCTION_SEPARATOR)}` +
+    ARGUMENT_SEPARATOR +
+    `${typeof argument === 'object' ? JSON.stringify(argument) : argument}`
+  );
 }
 
 module.exports = {

--- a/test/contract_execution_argument.test.js
+++ b/test/contract_execution_argument.test.js
@@ -4,29 +4,29 @@ const {
 } = require('../contract_execution_argument');
 
 test('if format works properly', () => {
-  expect(format('stringArgument', 'nonce', ['f1', 'f2'])).toEqual(
+  expect(format('nonce', ['f1', 'f2'], 'stringArgument')).toEqual(
       'V2\u0001nonce\u0003f1\u0002f2\u0003stringArgument',
   );
 
-  expect(format({foo: 'bar'}, 'nonce', ['f1', 'f2'])).toEqual(
+  expect(format('nonce', ['f1', 'f2'], {foo: 'bar'})).toEqual(
       'V2\u0001nonce\u0003f1\u0002f2\u0003{"foo":"bar"}',
   );
 
   expect(
-      format({foo: 'bar'}, 'nonce', ['f1', null, undefined, {}, 'f2']),
+      format('nonce', ['f1', null, undefined, {}, 'f2'], {foo: 'bar'}),
   ).toEqual('V2\u0001nonce\u0003f1\u0002f2\u0003{"foo":"bar"}');
 });
 
 test('if format can throw error', () => {
-  expect(() => format(1, 'nonce', ['f1', 'f2'])).toThrowError(
+  expect(() => format('nonce', ['f1', 'f2'], 1)).toThrowError(
       'argument must be a string or an object',
   );
 
-  expect(() => format('stringArgument', 0, ['f1', 'f2'])).toThrowError(
+  expect(() => format(0, ['f1', 'f2'], 'stringArgument')).toThrowError(
       'nonce must be a string',
   );
 
-  expect(() => format('stringArgument', 'nonce', {})).toThrowError(
+  expect(() => format('nonce', {}, 'stringArgument')).toThrowError(
       'functionIds must be an array',
   );
 });

--- a/test/contract_execution_argument.test.js
+++ b/test/contract_execution_argument.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable max-len */
+const {
+  format,
+  formatDeprecated,
+  getFunctionIds,
+} = require('../contract_execution_argument');
+
+test('if format works properly', () => {
+  expect(format('stringArgument', 'nonce', ['f1', 'f2'])).toEqual(
+      'V2\u0001nonce\u0003f1\u0002f2\u0003stringArgument',
+  );
+
+  expect(format({foo: 'bar'}, 'nonce', ['f1', 'f2'])).toEqual(
+      'V2\u0001nonce\u0003f1\u0002f2\u0003{"foo":"bar"}',
+  );
+
+  expect(
+      format({foo: 'bar'}, 'nonce', ['f1', null, undefined, {}, 'f2']),
+  ).toEqual('V2\u0001nonce\u0003f1\u0002f2\u0003{"foo":"bar"}');
+});
+
+test('if format can throw error', () => {
+  expect(() => format(1, 'nonce', ['f1', 'f2'])).toThrowError(
+      'argument must be a string or an object',
+  );
+
+  expect(() => format('stringArgument', 0, ['f1', 'f2'])).toThrowError(
+      'nonce must be a string',
+  );
+
+  expect(() => format('stringArgument', 'nonce', {})).toThrowError(
+      'functionIds must be an array',
+  );
+});
+
+test('if formatDeprecated works properly', () => {
+  expect(formatDeprecated({foo: 'bar'}, 'nonce')).toEqual(
+      '{"foo":"bar","nonce":"nonce"}',
+  );
+});
+
+test('if formatDeprecated can throw errors', () => {
+  expect(() => formatDeprecated('string', 'nonce')).toThrowError(
+      'argument must be an object',
+  );
+
+  expect(() => formatDeprecated({foo: 'bar'}, 0)).toThrowError(
+      'nonce must be a string',
+  );
+});
+
+test('if getFunctionIds works properly', () => {
+  expect(getFunctionIds({foo: 'bar'})).toEqual([]);
+
+  expect(getFunctionIds({_functions_: ['f1', 'f2']})).toEqual(['f1', 'f2']);
+});
+
+test('if getFunctionIds can throw error', () => {
+  expect(() => getFunctionIds(1)).toThrowError('argument must be an object');
+  expect(() => getFunctionIds({_functions_: 'not-array'})).toThrowError(
+      'argument._functions_ must be an array',
+  );
+});

--- a/test/contract_execution_argument.test.js
+++ b/test/contract_execution_argument.test.js
@@ -1,8 +1,6 @@
 /* eslint-disable max-len */
 const {
   format,
-  formatDeprecated,
-  getFunctionIds,
 } = require('../contract_execution_argument');
 
 test('if format works properly', () => {
@@ -30,34 +28,5 @@ test('if format can throw error', () => {
 
   expect(() => format('stringArgument', 'nonce', {})).toThrowError(
       'functionIds must be an array',
-  );
-});
-
-test('if formatDeprecated works properly', () => {
-  expect(formatDeprecated({foo: 'bar'}, 'nonce')).toEqual(
-      '{"foo":"bar","nonce":"nonce"}',
-  );
-});
-
-test('if formatDeprecated can throw errors', () => {
-  expect(() => formatDeprecated('string', 'nonce')).toThrowError(
-      'argument must be an object',
-  );
-
-  expect(() => formatDeprecated({foo: 'bar'}, 0)).toThrowError(
-      'nonce must be a string',
-  );
-});
-
-test('if getFunctionIds works properly', () => {
-  expect(getFunctionIds({foo: 'bar'})).toEqual([]);
-
-  expect(getFunctionIds({_functions_: ['f1', 'f2']})).toEqual(['f1', 'f2']);
-});
-
-test('if getFunctionIds can throw error', () => {
-  expect(() => getFunctionIds(1)).toThrowError('argument must be an object');
-  expect(() => getFunctionIds({_functions_: 'not-array'})).toThrowError(
-      'argument._functions_ must be an array',
   );
 });


### PR DESCRIPTION
This PR adds a class to serialize contract execution argument version 2.
Basically, it is the Node.js version of https://github.com/scalar-labs/scalar/blob/master/common/src/main/java/com/scalar/dl/ledger/util/Argument.java#L40

Note: In Node SDK we will use version 2 string serialization even for the old contract execution function.