### PR TITLE
Add additional property `nonce` for the contract execution request

### DIFF
--- a/index.js
+++ b/index.js
@@ -948,7 +948,8 @@ class ClientServiceBase {
         .withContractArgument(argumentJson)
         .withFunctionArgument(functionArgumentJson)
         .withCertHolderId(properties.getCertHolderId())
-        .withCertVersion(properties.getCertVersion());
+        .withCertVersion(properties.getCertVersion())
+        .withNonce(argument['nonce']);
 
     try {
       return builder.build();

--- a/request/builder.js
+++ b/request/builder.js
@@ -623,6 +623,7 @@ class ContractExecutionRequestBuilder {
     validator.validateInput(this.certVersion, Number);
     validator.validateInput(this.functionArgument, String, true);
     validator.validateInput(this.useFunctionIds, Boolean);
+    validator.validateInput(this.nonce, String);
 
     const request = this.request;
     request.setContractId(this.contractId);

--- a/request/builder.js
+++ b/request/builder.js
@@ -602,6 +602,15 @@ class ContractExecutionRequestBuilder {
   }
 
   /**
+   * @param {string} nonce
+   * @return {ContractExecutionRequestBuilder}
+   */
+  withNonce(nonce) {
+    this.nonce = nonce;
+    return this;
+  }
+
+  /**
    * Builds the ContractExecutionRequest
    * @throws {Error}
    * @return {ContractExecutionRequest}
@@ -623,6 +632,7 @@ class ContractExecutionRequestBuilder {
     request.setFunctionArgument(this.functionArgument);
     request.setUseFunctionIds(this.useFunctionIds);
     request.setFunctionIdsList(this.functionIds);
+    request.setNonce(this.nonce);
 
     const contractIdEncoded = new TextEncoder('utf-8').encode(this.contractId);
     const contractArgument = new TextEncoder('utf-8').encode(

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -569,6 +569,7 @@ describe('executeContract', () => {
       setSignature: function() {},
       setUseFunctionIds: function() {},
       setFunctionIdsList: function() {},
+      setNonce: function() {},
     };
     const mockedProtobuf = {
       ContractExecutionRequest: function() {
@@ -782,6 +783,7 @@ describe('validateLedger linearizably', () => {
         setAuditorSignature: function() {},
         setUseFunctionIds: function() {},
         setFunctionIdsList: function() {},
+        setNonce: function() {},
       }),
       ExecutionValidationRequest: () => ({
         setRequest: function() {},


### PR DESCRIPTION
This PR adds `nonce` to the contract execution request.