### PR TITLE
Revise executeContract

### DIFF
--- a/index.js
+++ b/index.js
@@ -459,18 +459,33 @@ class ClientServiceBase {
   /**
    * Execute a registered contract
    * @param {string} contractId
+   * @param {Object} contractArgument
+   * @param {Object} [functionArgument=null]
+   */
+  async executeContract(contractId, contractArgument, functionArgument) {
+    return this.execute(
+        contractId,
+        contractArgument,
+        null,
+        functionArgument,
+    );
+  }
+
+  /**
+   * Execute a registered contract and function (optionally)
+   * @param {string} contractId
    * @param {Object|string} contractArgument
-   * @param {Object|string} [functionArgument=null]
    * @param {string} [functionId=null]
+   * @param {Object|string} [functionArgument=null]
    * @param {string} [nonce=null]
    * @return {Promise<ContractExecutionResult|void|*>}
    * @throws {ClientError|Error}
    */
-  async executeContract(
+  async execute(
       contractId,
       contractArgument,
-      functionArgument = null,
       functionId = null,
+      functionArgument = null,
       nonce = null,
   ) {
     if (functionArgument === null) {

--- a/index.js
+++ b/index.js
@@ -458,6 +458,7 @@ class ClientServiceBase {
 
   /**
    * Execute a registered contract
+   * @deprecated Use {@link execute} instead
    * @param {string} contractId
    * @param {Object} contractArgument
    * @param {Object} [functionArgument=null]

--- a/index.js
+++ b/index.js
@@ -461,7 +461,7 @@ class ClientServiceBase {
    * @param {string} contractId
    * @param {Object|string} contractArgument
    * @param {Object|string} [functionArgument=null]
-   * @param {string} [functionId=""]
+   * @param {string} [functionId=null]
    * @param {string} [nonce=null]
    * @return {Promise<ContractExecutionResult|void|*>}
    * @throws {ClientError|Error}
@@ -470,7 +470,7 @@ class ClientServiceBase {
       contractId,
       contractArgument,
       functionArgument = null,
-      functionId = '',
+      functionId = null,
       nonce = null,
   ) {
     if (functionArgument === null) {

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -560,7 +560,7 @@ describe('executeContract', () => {
 
     // action and assert
     await expect(
-        clientServiceBase.executeContract('id', 'string', {}),
+        clientServiceBase.execute('id', 'string', null, {}),
     ).rejects.toThrowError(
         'contract argument and function argument must be the same type',
     );
@@ -599,11 +599,11 @@ describe('executeContract', () => {
 
     // action and assert
     await expect(
-        clientServiceBase.executeContract(
+        clientServiceBase.execute(
             'contract-id',
             'contract-argument',
-            'function-argument',
             'function-id',
+            'function-argument',
             {},
         ),
     ).rejects.toThrowError('nonce must be a string');
@@ -701,11 +701,11 @@ describe('executeContract', () => {
     );
 
     // act
-    const response = await clientServiceBase.executeContract(
+    const response = await clientServiceBase.execute(
         mockedContractId,
         mockedArgument,
-        mockedFunctionArgument,
         mockedFunctionId,
+        mockedFunctionArgument,
         'nonce',
     );
 

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -554,10 +554,66 @@ describe('executeContract', () => {
     ).rejects.toThrowError();
   });
 
+  test('should throw error when the type of the contract argument and the function argument is different', async () => {
+    // arrange
+    const clientServiceBase = new ClientServiceBase({}, {}, clientProperties);
+
+    // action and assert
+    await expect(
+        clientServiceBase.executeContract('id', 'string', {}),
+    ).rejects.toThrowError(
+        'contract argument and function argument must be the same type',
+    );
+  });
+
+  test('should throw error is nonce is not string', async () => {
+    // arrange
+    const mockedExecuteContract = {
+      setContractId: function() {},
+      setContractArgument: function() {},
+      setCertHolderId: function() {},
+      setCertVersion: function() {},
+      setFunctionArgument: function() {},
+      setSignature: function() {},
+      setUseFunctionIds: function() {},
+      setFunctionIdsList: function() {},
+      setNonce: function() {},
+    };
+    const mockedProtobuf = {
+      ContractExecutionRequest: function() {
+        return mockedExecuteContract;
+      },
+    };
+    const clientServiceBase = new ClientServiceBase(
+        {
+          ledgerClient: {},
+          signerFactory: {
+            create: () => ({
+              sign: () => {},
+            }),
+          },
+        },
+        mockedProtobuf,
+        clientProperties,
+    );
+
+    // action and assert
+    await expect(
+        clientServiceBase.executeContract(
+            'contract-id',
+            'contract-argument',
+            'function-argument',
+            'function-id',
+            {},
+        ),
+    ).rejects.toThrowError('nonce must be a string');
+  });
+
   // prepare
-  const mockedContractId = '12345';
-  const mockedArgument = {mocked: 'argument'};
-  const mockedFunctionArgument = 'mockedFunctionArgument';
+  const mockedContractId = 'contract-id';
+  const mockedFunctionId = 'function-id';
+  const mockedArgument = {mocked: 'contact-argument'};
+  const mockedFunctionArgument = {mocked: 'function-argument'};
   const mockedFunctionArgumentJson = JSON.stringify(mockedFunctionArgument);
   test('should work as expected', async () => {
     const mockedExecuteContract = {
@@ -638,21 +694,26 @@ describe('executeContract', () => {
     );
     const mockSpySign = jest.spyOn(mockedSigner, 'sign');
 
+    const spiedSetNonce = jest.spyOn(mockedExecuteContract, 'setNonce');
+    const spiedSetFunctionIdsList = jest.spyOn(
+        mockedExecuteContract,
+        'setFunctionIdsList',
+    );
+
     // act
     const response = await clientServiceBase.executeContract(
         mockedContractId,
         mockedArgument,
         mockedFunctionArgument,
+        mockedFunctionId,
+        'nonce',
     );
 
     // assert
     expect(mockSpyContractExecutionRequest).toBeCalledTimes(1);
     expect(mockSpySetContractId).toBeCalledWith(mockedContractId);
     expect(mockSpySetContractArgument).toBeCalledWith(
-        expect.stringContaining('argument'),
-    );
-    expect(mockSpySetContractArgument).toBeCalledWith(
-        expect.stringContaining('nonce'),
+        'V2\u0001nonce\u0003function-id\u0003{"mocked":"contact-argument"}',
     );
     expect(mockSpySetCertHolderId).toBeCalledWith(
         clientProperties['scalar.dl.client.cert_holder_id'],
@@ -665,6 +726,8 @@ describe('executeContract', () => {
     expect(mockSpySetFunctionArgument).toBeCalledWith(
         mockedFunctionArgumentJson,
     );
+    expect(spiedSetNonce).toBeCalledWith('nonce');
+    expect(spiedSetFunctionIdsList).toBeCalledWith(['function-id']);
 
     expect(response).toBeInstanceOf(ContractExecutionResult);
 


### PR DESCRIPTION
This PR revises the `executeContract` function to support Scalar DL 3.5.