### PR TITLE
Always do the linearizable validation when Scalar DL is in the Auditor mode

### DIFF
--- a/client_properties.js
+++ b/client_properties.js
@@ -14,8 +14,6 @@ const ClientPropertiesField = {
   AUDITOR_HOST: 'scalar.dl.client.auditor.host',
   AUDITOR_PORT: 'scalar.dl.client.auditor.port',
   AUDITOR_PRIVILEGED_PORT: 'scalar.dl.client.auditor.privileged_port',
-  AUDITOR_LINEARIZABLE_VALIDATION_ENABLED:
-    'scalar.dl.client.auditor.linearizable_validation.enabled',
   AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID:
     'scalar.dl.client.auditor.linearizable_validation.contract_id',
   TLS_CA_ROOT_CERT_PEM: 'scalar.dl.client.tls.ca_root_cert_pem',
@@ -65,11 +63,6 @@ defaultSchema.properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT] = {
   type: 'number',
 };
 defaultSchema.properties[
-    ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
-] = {
-  type: 'boolean',
-};
-defaultSchema.properties[
     ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
 ] = {
   type: 'string',
@@ -100,9 +93,6 @@ function defaultProperties() {
   properties[ClientPropertiesField.AUDITOR_HOST] = 'localhost';
   properties[ClientPropertiesField.AUDITOR_PORT] = 40051;
   properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT] = 40052;
-  properties[
-      ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
-  ] = false;
   properties[
       ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
   ] = 'validate-ledger';
@@ -152,12 +142,6 @@ class ClientProperties {
     }
 
     if (properties[ClientPropertiesField.AUDITOR_ENABLED] !== true) {
-      properties[
-          ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
-      ] =
-        theDefaultProperties[
-            ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
-        ];
       properties[
           ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_CONTRACT_ID
       ] =
@@ -251,15 +235,6 @@ class ClientProperties {
    */
   getAuditorPrivilegedPort() {
     return this.properties[ClientPropertiesField.AUDITOR_PRIVILEGED_PORT];
-  }
-
-  /**
-   * @return {Boolean}
-   */
-  getAuditorLinearizableValidationEnabled() {
-    return this.properties[
-        ClientPropertiesField.AUDITOR_LINEARIZABLE_VALIDATION_ENABLED
-    ];
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -391,7 +391,26 @@ class ClientServiceBase {
           startAge,
           endAge,
       );
-      return this._validateLedger(request);
+
+      const promise = new Promise((resolve, reject) => {
+        this.ledgerClient.validateLedger(
+            request,
+            this.metadata,
+            (err, response) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve(
+                    LedgerValidationResult.fromGrpcLedgerValidationResponse(
+                        response,
+                    ),
+                );
+              }
+            },
+        );
+      });
+
+      return this._executePromise(promise);
     }
   }
 
@@ -424,34 +443,6 @@ class ClientServiceBase {
       ledgerProofs.length > 0 ? ledgerProofs[0] : null,
       auditorProofs.length > 0 ? ledgerProofs[0] : null,
     );
-  }
-
-  /**
-   * @param {LedgerValidationRequest} request
-   * @return {Promise<LedgerValidationResult>}
-   * @throws {ClientError|Error}
-   */
-  async _validateLedger(request) {
-    let promises;
-    const ledgerPromise = this._executePromise(
-        this._validateLedgerAsync(this.ledgerClient, request),
-    );
-    if (this._isAuditorEnabled()) {
-      const auditorPromise = this._executePromise(
-          this._validateLedgerAsync(this.auditorClient, request),
-      );
-      promises = [ledgerPromise, auditorPromise];
-    } else {
-      promises = [ledgerPromise];
-    }
-
-    return Promise.all(promises)
-        .then((results) => {
-          return this._validateResult(results[0], results[1]);
-        })
-        .catch((e) => {
-          throw e;
-        });
   }
 
   /**
@@ -1043,33 +1034,6 @@ class ClientServiceBase {
     this.signer = this.signer || this.signerFactory.create(key);
 
     return this.signer;
-  }
-
-  /**
-   * @param {LedgerValidationResult} ledgerResult
-   * @param {LedgerValidationResult} auditorResult
-   * @return {LedgerValidationResult}
-   */
-  _validateResult(ledgerResult, auditorResult) {
-    if (this._isAuditorEnabled()) {
-      let code = StatusCode.INCONSISTENT_STATES;
-      if (
-        ledgerResult.getCode() === StatusCode.OK &&
-        auditorResult.getCode() === StatusCode.OK &&
-        ledgerResult.getProof() !== null &&
-        auditorResult.getProof() !== null &&
-        ledgerResult.getProof().hashEquals(auditorResult.getProof().getHash())
-      ) {
-        code = StatusCode.OK;
-      }
-      return new LedgerValidationResult(
-          code,
-          ledgerResult.getProof(),
-          auditorResult.getProof(),
-      );
-    } else {
-      return ledgerResult;
-    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -378,10 +378,7 @@ class ClientServiceBase {
     }
 
     const properties = new ClientProperties(this.properties, [], []);
-    if (
-      properties.getAuditorEnabled() &&
-      properties.getAuditorLinearizableValidationEnabled
-    ) {
+    if (properties.getAuditorEnabled()) {
       return this._validateLedgerWithContractExecution(
           assetId,
           startAge,

--- a/index.js
+++ b/index.js
@@ -739,27 +739,6 @@ class ClientServiceBase {
   }
 
   /**
-   * @param {LedgerClient|AuditorClient} client
-   * @param {LedgerValidationRequest} request
-   * @return {Promise}
-   * @throws {ClientError}
-   */
-  async _validateLedgerAsync(client, request) {
-    const promise = new Promise((resolve, reject) => {
-      client.validateLedger(request, this.metadata, (err, response) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(
-              LedgerValidationResult.fromGrpcLedgerValidationResponse(response),
-          );
-        }
-      });
-    });
-    return promise;
-  }
-
-  /**
    * @param {Promise} promise
    * @return {Promise}
    * @throws {ClientError}

--- a/test/client_properties.test.js
+++ b/test/client_properties.test.js
@@ -139,7 +139,6 @@ test('should overwrite default values of default properties', () => {
 
 test('should have default linearizable properties', () => {
   const properties = new ClientProperties({}, [], []);
-  expect(properties.getAuditorLinearizableValidationEnabled()).toEqual(false);
   expect(properties.getAuditorLinearizableValidationContractId()).toEqual(
       'validate-ledger',
   );
@@ -149,13 +148,11 @@ test('should be able to configure linearizable properties in auditor mode', () =
   const properties = new ClientProperties(
       {
         'scalar.dl.client.auditor.enabled': true,
-        'scalar.dl.client.auditor.linearizable_validation.enabled': true,
         'scalar.dl.client.auditor.linearizable_validation.contract_id': 'foo',
       },
       [],
       [],
   );
-  expect(properties.getAuditorLinearizableValidationEnabled()).toEqual(true);
   expect(properties.getAuditorLinearizableValidationContractId()).toEqual(
       'foo',
   );
@@ -168,13 +165,11 @@ test(
       const properties = new ClientProperties(
           {
             'scalar.dl.client.auditor.enabled': false,
-            'scalar.dl.client.auditor.linearizable_validation.enabled': true,
             'scalar.dl.client.auditor.linearizable_validation.contract_id': 'foo',
           },
           [],
           [],
       );
-      expect(properties.getAuditorLinearizableValidationEnabled()).toEqual(false);
       expect(properties.getAuditorLinearizableValidationContractId()).toEqual(
           'validate-ledger',
       );

--- a/test/client_service_base.test.js
+++ b/test/client_service_base.test.js
@@ -911,7 +911,6 @@ describe('validateLedger linearizably', () => {
         {
           ...clientProperties,
           'scalar.dl.client.auditor.enabled': true,
-          'scalar.dl.client.auditor.linearizable_validation.enable': true,
         },
     );
 


### PR DESCRIPTION
This PR aligns the JavaScript SDKs to https://github.com/scalar-labs/scalar/pull/841

When the Scalar DL is in Auditor mode, we should always use linearizable validation to validate the ledger.