### PR TITLE
Implement createSerializedExecutionRequest function

### DIFF
--- a/index.js
+++ b/index.js
@@ -621,7 +621,7 @@ class ClientServiceBase {
   async createSerializedExecutionRequest(
       contractId,
       contractArgument,
-      functionId,
+      functionId = null,
       functionArgument = null,
       nonce = null,
   ) {

--- a/index.js
+++ b/index.js
@@ -609,6 +609,48 @@ class ClientServiceBase {
   }
 
   /**
+   * Create the byte array of ContractExecutionRequest
+   * @param {string} contractId
+   * @param {Object|string} contractArgument
+   * @param {string} [functionId=null]
+   * @param {Object|string} [functionArgument=null]
+   * @param {string} [nonce=null]
+   * @return {Promise<Uint8Array>}
+   * @throws {ClientError|Error}
+   */
+  async createSerializedExecutionRequest(
+      contractId,
+      contractArgument,
+      functionId,
+      functionArgument = null,
+      nonce = null,
+  ) {
+    if (functionArgument === null) {
+      functionArgument = typeof contractArgument === 'object' ? {} : '';
+    }
+
+    if (typeof contractArgument !== typeof functionArgument) {
+      throw Error(
+          'contract argument and function argument must be the same type',
+      );
+    }
+
+    if (nonce === null) {
+      nonce = uuidv4();
+    }
+
+    const request = await this._createContractExecutionRequest(
+        contractId,
+        functionId,
+        contractArgument,
+        functionArgument,
+        nonce,
+    );
+
+    return request.serializeBinary();
+  }
+
+  /**
    * @return {Boolean}
    */
   _isAuditorEnabled() {

--- a/index.js
+++ b/index.js
@@ -587,6 +587,7 @@ class ClientServiceBase {
 
   /**
    * Create the byte array of ContractExecutionRequest
+   * @deprecated Use {@link createSerializedExecutionRequest} instead
    * @param {string} contractId
    * @param {Object} argument
    * @param {Object} [functionArgument=undefined]

--- a/test/client_service_base_binary.test.js
+++ b/test/client_service_base_binary.test.js
@@ -80,3 +80,51 @@ test('createSerializedContractExecutionRequest passes parameters properly', asyn
   );
   expect(spied3).toBeCalledWith('{"function-argument-1":"b"}');
 });
+
+test('createSerializedExecutionRequest passes parameters properly', async () => {
+  // Arrange;
+  const base = new ClientServiceBase(services, protobuf, properties);
+  const spied1 = jest.spyOn(mockedContractExecutionRequest, 'setContractId');
+  const spied2 = jest.spyOn(mockedContractExecutionRequest, 'setFunctionIdsList');
+  const spied3 = jest.spyOn(
+      mockedContractExecutionRequest,
+      'setContractArgument',
+  );
+  const spied4 = jest.spyOn(
+      mockedContractExecutionRequest,
+      'setFunctionArgument',
+  );
+
+  // Action;
+  await base.createSerializedExecutionRequest(
+      'contract-id',
+      {'contract-argument-1': 'a'},
+      'function-id',
+      {'function-argument-1': 'b'},
+      'nonce',
+  );
+
+  // Assert
+  expect(spied1).toBeCalledWith('contract-id');
+  expect(spied2).toBeCalledWith(['function-id']);
+  expect(spied3).toBeCalledWith(
+      expect.stringContaining('{"contract-argument-1":"a"}'),
+  );
+  expect(spied4).toBeCalledWith('{"function-argument-1":"b"}');
+});
+
+test('createSerializedExecutionRequest throws error when argument types are not the same', async () => {
+  // Arrange;
+  const base = new ClientServiceBase(services, protobuf, properties);
+
+  // Action;
+
+  // Assert
+  await expect(base.createSerializedExecutionRequest(
+      'contract-id',
+      {'contract-argument-1': 'a'},
+      'function-id',
+      '{"function-argument-1":"b"}',
+      'nonce',
+  )).rejects.toThrowError('contract argument and function argument must be the same type');
+});


### PR DESCRIPTION
This PR implements createSerializedExecutionRequest function to serialize the contract execution request.

It has a different interface from the createSerializedContractExecutionRequest function.